### PR TITLE
port modification to Dockerfile

### DIFF
--- a/agentic_interface/Dockerfile
+++ b/agentic_interface/Dockerfile
@@ -30,6 +30,6 @@
     EXPOSE 8000
     
     # --- 10. Start server with Gunicorn + Uvicorn workers ---
-    CMD ["uvicorn", "main_agent:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "4"]
+    CMD ["uvicorn", "main_agent:app", "--host", "0.0.0.0", "--port", "${PORT}", "--workers", "4"]
 
     


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Use environment variable PORT for Uvicorn in Dockerfile instead of hardcoded 8000.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e14272a54522d2ff01527777b256c844ea819ec8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->